### PR TITLE
#341: enable generic aot build

### DIFF
--- a/dist/dist-linux/graal-linux/pom.xml
+++ b/dist/dist-linux/graal-linux/pom.xml
@@ -82,7 +82,7 @@
                     <outputDirectory>${native.output.dir}</outputDirectory>
                     <mainClass>${main.class}</mainClass>
                     <buildArgs>
-                        <buildArg>-march=native</buildArg>
+                        <buildArg>-march=compatibility</buildArg>
                         <buildArg>-H:ConfigurationFileDirectories=${basedir}/src/main/resources/</buildArg>
                         <buildArg>-H:+UnlockExperimentalVMOptions</buildArg>
                         <buildArg>-H:+CompactingOldGen</buildArg>


### PR DESCRIPTION
This pull request enables a mode of GraalVM where the binary is optimised for generic compatibility (no optimisations)